### PR TITLE
btrfs_subvol_usage: fix "btrfs qgroup show" output format

### DIFF
--- a/plugins/disk/btrfs_subvol_usage
+++ b/plugins/disk/btrfs_subvol_usage
@@ -62,7 +62,7 @@ while (my $line = <SVS>) {
 close SVS;
 
 # get sizes from quota
-open(QGS, "btrfs qgroup show @fsroot |")
+open(QGS, "btrfs qgroup show --raw @fsroot |")
 	or die("Failed to run 'btrfs qgroup show': " . $!);
 while (my $line = <QGS>) {
 	chomp $line;


### PR DESCRIPTION
Switch "btrfs qgroup show" for raw output format, because by default it's human readable form and can't be read by scripts.